### PR TITLE
Show real-world usage setup, instead of a one-off.

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ To send a `Mail::Message` via Postmark you’ll need to specify `Mail::Postmark`
 a delivery method for the message:
 
 ``` ruby
-message = Mail.new do
+Mail.defaults do
   # ...
   delivery_method Mail::Postmark, api_token: 'your-postmark-api-token'
 end


### PR DESCRIPTION
In real-world applications you are more likely to set the Mail gem to use postmark as a delivery methods on a `Mail.defaults` call, instead of doing it on each email-sending piece of code.
